### PR TITLE
퀴즈 데이터 요청 API 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -4946,6 +4947,28 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -20244,6 +20267,27 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/hooks/useFetchQuiz.js
+++ b/src/hooks/useFetchQuiz.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+export const useFetchQuiz = () => {
+  const [quizLists, setQuizLists] = useState([]);
+  const [quizNumber, setQuizNumber] = useState(10);
+  const [quizCategory, setQuizCategory] = useState("9");
+  const [quizDifficulty, setQuizDifficulty] = useState("easy");
+
+  const baseURL = process.env.REACT_APP_API_URL;
+
+  useEffect(() => {
+    axios
+      .get(
+        `${baseURL}amount=${quizNumber}&difficulty=${quizDifficulty}&category=${quizCategory}`
+      )
+      .then((res) => {
+        setQuizLists(
+          res.data.results.map((quizList, index) => {
+            return {
+              id: index,
+              questions: quizList.question,
+              answer: quizList.correct_answer,
+              options: [...quizList.incorrect_answers].sort(
+                () => Math.random - 0.5
+              ),
+            };
+          })
+        );
+      });
+  }, []);
+
+  return [
+    quizLists,
+    setQuizLists,
+    quizNumber,
+    setQuizNumber,
+    quizCategory,
+    setQuizCategory,
+    quizDifficulty,
+    setQuizDifficulty,
+  ];
+};


### PR DESCRIPTION
## 요약
- 퀴즈 데이터 API 관련 로직 작성하였습니다
 
## 변경내용
- `axios` 설치하였습니다
- API 데이터 요청 관련 주소 환경변수 처리하였습니다 
- API 데이터 요청 관련 custom hook 작성하였습니다
```
useEffect(() => {
    axios
      .get(
        `${baseURL}amount=${quizNumber}&difficulty=${quizDifficulty}&category=${quizCategory}`
      )
      .then((res) => {
        setQuizLists(
          res.data.results.map((quizList, index) => {
            return {
              id: index,
              questions: quizList.question,
              answer: quizList.correct_answer,
              options: [...quizList.incorrect_answers].sort(
                () => Math.random - 0.5
              ),
            };
          })
        );
      });
  }, []);
```

## 특이사항
- 퀴즈 설정 관련 로직은 모달구현시 변경 필요할 것 같습니다.
